### PR TITLE
Dependencies bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth1"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ryan Leckey <leckey.ryan@gmail.com>"]
 description = "Basic OAuth1 library for Rust."
 license = "MIT/Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["oauth", "oauth1"]
 
 [dependencies]
 time = "0.1"
-rand = "0.3"
-url = "1.5"
-ring = "0.13.0-alpha"
-base64 = "0.7.0"
+rand = "0.6"
+url = "1.7"
+ring = "0.14"
+base64 = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ extern crate url;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use rand::Rng;
+use std::iter;
+use rand::{Rng, thread_rng};
+use rand::distributions::Alphanumeric;
 use url::percent_encoding;
 use ring::{digest, hmac};
 
@@ -38,7 +40,9 @@ pub fn authorize(
 ) -> String {
     let mut params = params.unwrap_or_else(HashMap::new);
     let timestamp = time::now_utc().to_timespec().sec.to_string();
-    let nonce: String = rand::thread_rng().gen_ascii_chars().take(32).collect();
+    let mut rng = thread_rng();
+    let nonce: String = iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric)).take(32).collect();
 
     params.insert("oauth_consumer_key", consumer.key.clone().into());
     params.insert("oauth_nonce", nonce.into());


### PR DESCRIPTION
Fixes #6

Also bumps crate's version to v0.3.1; ready for a release.