### PR TITLE
Remove dependency on time, use std::time instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/mehcode/oauth1-rs"
 keywords = ["oauth", "oauth1"]
 
 [dependencies]
-time = "0.2.2"
 rand = "0.7.3"
 ring = "0.16.9"
 base64 = "0.11.0"


### PR DESCRIPTION
there's no need to depend on a separate crate to get the unix timestamp. Would like to remove the dependency if you agree