### PR TITLE
cargo: update ring to avoid segfault

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["oauth", "oauth1"]
 [dependencies]
 time = "0.2.2"
 rand = "0.7.3"
-ring = "0.16.9"
+ring = "0.16.20"
 base64 = "0.11.0"
 percent-encoding = "2.1.0"
 serde = { version = "1", optional = true, features = [ "derive" ] }


### PR DESCRIPTION
When building a package that depends on `oauth1`, I got this error:

```
instapaper-rs $ cargo build                                                                                                                                                                                [121/403]
   Compiling failure v0.1.3
   Compiling ring v0.12.1
   Compiling reqwest v0.9.4
error: failed to run custom build command for `ring v0.12.1`

Caused by:
  process didn't exit successfully: `/Users/work/src/github.com/sirupsen/instapaper-rs/target/debug/build/ring-0e15c2552dc743d0/build-script-build` (signal: 11, SIGSEGV: invalid memory reference)
  --- stdout
  ALACRITTY_LOG: /var/folders/ch/_pklv2hx6zl4sr9tpyxtxb7m0000gn/T/Alacritty-2161.log
  BIGTABLE_EMULATOR_HOST: localhost:8086
  BUTTONDOWN_TOKEN: 9fcbc0d5-578c-4d84-8dc0-dd4dee3832ff
  CARGO: /Users/work/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo
  CARGO_CFG_TARGET_ARCH: x86_64
  CARGO_CFG_TARGET_ENDIAN: little
  CARGO_CFG_TARGET_ENV:
  CARGO_CFG_TARGET_FAMILY: unix
  CARGO_CFG_TARGET_FEATURE: fxsr,sse,sse2,sse3,ssse3
  CARGO_CFG_TARGET_OS: macos
  CARGO_CFG_TARGET_POINTER_WIDTH: 64
  CARGO_CFG_TARGET_VENDOR: apple
  CARGO_CFG_UNIX:
  CARGO_FEATURE_DEFAULT: 1
  CARGO_FEATURE_DEV_URANDOM_FALLBACK: 1
  CARGO_FEATURE_USE_HEAP: 1

  --- stderr
  thread '<unnamed>' panicked at 'attempted to leave type `nodrop::NoDrop<(epoch::Epoch, garbage::Bag)>` uninitialized, which is invalid', /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/core/src/mem/mod.
rs:671:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Resolved by upgrading the `ring` dependency :)